### PR TITLE
fix metric bug, add details to test and rst doc

### DIFF
--- a/docs/selection/ShuffleFeaturesSelector.rst
+++ b/docs/selection/ShuffleFeaturesSelector.rst
@@ -1,0 +1,80 @@
+ShuffleFeaturesSelector
+=======================
+
+The ShuffleFeaturesSelector() selects important features if permutation their values
+at random produces a decrease in the initial model performance. See API below for
+more details into its functionality.
+
+.. code:: python
+
+    import pandas as pd
+    from sklearn.datasets import load_diabetes
+    from sklearn.linear_model import LinearRegression
+    from feature_engine.selection import ShuffleFeaturesSelector
+
+    # load dataset
+    diabetes_X, diabetes_y = load_diabetes(return_X_y=True)
+    X = pd.DataFrame(diabetes_X)
+    y = pd.DataFrame(diabetes_y)
+
+    # initialize linear regresion estimator
+    linear_model = LinearRegression()
+
+    # initialize feature selector
+    tr = ShuffleFeaturesSelector(estimator=linear_model, scoring="r2", cv=3)
+
+    # fit transformer
+    Xt = tr.fit_transform(X, y)
+
+    tr.initial_model_performance_
+
+
+.. code:: python
+
+    0.488702767247119
+
+..  code:: python
+
+    tr.performance_drifts_
+
+.. code:: python
+
+    {0: -0.02368121940502793,
+     1: 0.017909161264480666,
+     2: 0.18565460365508413,
+     3: 0.07655405817715671,
+     4: 0.4327180164470878,
+     5: 0.16394693824418372,
+     6: -0.012876023845921625,
+     7: 0.01048781540981647,
+     8: 0.3921465005640224,
+     9: -0.01427065640301245}
+
+.. code:: python
+
+    tr.selected_features_
+
+.. code:: python
+
+    [1, 2, 3, 4, 5, 7, 8]
+
+.. code:: python
+
+    print(print(Xt.head()))
+
+.. code:: python
+
+              1         2         3         4         5         7         8
+    0  0.050680  0.061696  0.021872 -0.044223 -0.034821 -0.002592  0.019908
+    1 -0.044642 -0.051474 -0.026328 -0.008449 -0.019163 -0.039493 -0.068330
+    2  0.050680  0.044451 -0.005671 -0.045599 -0.034194 -0.002592  0.002864
+    3 -0.044642 -0.011595 -0.036656  0.012191  0.024991  0.034309  0.022692
+    4 -0.044642 -0.036385  0.021872  0.003935  0.015596 -0.002592 -0.031991
+    None
+
+
+API Reference
+-------------
+
+.. autoclass:: feature_engine.selection.ShuffleFeaturesSelector
+    :members:

--- a/feature_engine/selection/shuffle_features.py
+++ b/feature_engine/selection/shuffle_features.py
@@ -76,14 +76,14 @@ class ShuffleFeaturesSelector(BaseEstimator, TransformerMixin):
 
     selected_features_: list
         The selected features.
-        
+
     Methods
     -------
-    
+
     fit: finds important features
-    
+
     transform: removes non-important / non-selected features
-    
+
     fit_transform: finds and removes non-important features
 
     """
@@ -97,8 +97,8 @@ class ShuffleFeaturesSelector(BaseEstimator, TransformerMixin):
         variables=None,
     ):
 
-        if not isinstance(cv, int) or cv < 0:
-            raise ValueError("cv can only take positive integers")
+        if not isinstance(cv, int) or cv < 1:
+            raise ValueError("cv can only take positive integers bigger than 1")
 
         if not isinstance(threshold, (int, float)):
             raise ValueError("threshold can only be integer or float")
@@ -114,7 +114,7 @@ class ShuffleFeaturesSelector(BaseEstimator, TransformerMixin):
 
         Args
         ----
-            
+
         X: pandas dataframe of shape = [n_samples, n_features]
            The input dataframe
 
@@ -124,7 +124,7 @@ class ShuffleFeaturesSelector(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        
+
         self
         """
 
@@ -172,18 +172,12 @@ class ShuffleFeaturesSelector(BaseEstimator, TransformerMixin):
             )
 
             # determine drift in performance
-            if self.scoring in [
-                "median_absolute_error",
-                "max_error",
-                "mean_absolute_error",
-                "mean_squared_error",
-            ]:
-                # if feature is important, mean absolute error will be bigger
-                performance_drift = performance - self.initial_model_performance_
-
-            else:
-                # if feature is important, roc will be smaller
-                performance_drift = self.initial_model_performance_ - performance
+            # Note, sklearn negates the log and error scores, so no need to manually
+            # do the invertion
+            # https://scikit-learn.org/stable/modules/model_evaluation.html
+            # (https://scikit-learn.org/stable/modules/model_evaluation.html
+            # #the-scoring-parameter-defining-model-evaluation-rules)
+            performance_drift = self.initial_model_performance_ - performance
 
             # Save feature and performance drift
             self.performance_drifts_[feature] = performance_drift
@@ -206,14 +200,14 @@ class ShuffleFeaturesSelector(BaseEstimator, TransformerMixin):
 
         Args
         ----
-            
+
         X: pandas dataframe of shape = [n_samples, n_features].
             The input dataframe from which feature values will be shuffled.
 
 
         Returns
         -------
-        
+
         X_transformed: pandas dataframe
             of shape = [n_samples, n_features - len(dropped features)]
             Pandas dataframe with the selected features.


### PR DESCRIPTION
@SunnyxBd thanks for the heads-up on the sklearn metrics. I wasn't aware that they negate. That was a very good catch.

The tests were a good start. They were a bit general. They needed a bit more detail to test the real outputs of the transformation.

What I normally do, is replay the lines of code (that are inside the transformer) in a Jupyter notebook, to understand what the outputs are and that they make sense, and then hard code those values in the tests.

Hopefully these changes finish the transformer and docs. Would you please check and merge?

thanks a lot!